### PR TITLE
Convert social commands to slash commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.py
+__pycache__

--- a/cogs/events/errors.py
+++ b/cogs/events/errors.py
@@ -10,31 +10,31 @@ class error(commands.Cog, name="Error"):
         self.bot = bot
 
     @commands.Cog.listener()
-    async def on_command_error(self, ctx, err):
+    async def on_application_command_error(self, ctx, err):
         if isinstance(err, commands.CommandNotFound):
             return
 
         if isinstance(err, commands.MissingPermissions):
             perms = "`" + '`, `'.join(err.missing_permissions) + "`"
-            return await ctx.send("{} **You are missing {} permissions.**".format(config.crossmark, perms))
+            return await ctx.respond("{} **You are missing {} permissions.**".format(config.crossmark, perms), ephemeral=True)
 
         if isinstance(err, commands.BotMissingPermissions):
             perms = "`" + '`, `'.join(err.missing_permissions) + "`"
-            return await ctx.send("{} **I'm missing {} permissions**".format(config.crossmark, perms))
+            return await ctx.respond("{} **I'm missing {} permissions**".format(config.crossmark, perms), ephemeral=True)
 
         if isinstance(err, commands.MissingRequiredArgument):
-            return await ctx.send("{} **`{}` is a required argument!**".format(config.crossmark, err.param.name))
+            return await ctx.respond("{} **`{}` is a required argument!**".format(config.crossmark, err.param.name), ephemeral=True)
 
         if isinstance(err, commands.CommandOnCooldown):
-            return await ctx.send(
+            return await ctx.respond(
                 "{} **This command is on cooldown for __{:.0f}__ more seconds.**".format(config.crossmark,
-                                                                                         err.retry_after))
+                                                                                         err.retry_after), ephemeral=True)
 
         if isinstance(err, commands.MemberNotFound):
-            return await ctx.send("{0} **Could not find user `{1}`**".format(config.confused, err.argument))
+            return await ctx.respond("{0} **Could not find user `{1}`**".format(config.confused, err.argument), ephemeral=True)
 
         if isinstance(err, discord.NotFound):
-            return await ctx.send("I could not find the argument you have provided.")
+            return await ctx.respond("I could not find the argument you have provided.", ephemeral=True)
 
 
 def setup(bot):

--- a/cogs/events/errors.py
+++ b/cogs/events/errors.py
@@ -16,22 +16,17 @@ class error(commands.Cog, name="Error"):
 
         if isinstance(err, commands.MissingPermissions):
             perms = "`" + '`, `'.join(err.missing_permissions) + "`"
-            return await ctx.respond("{} **You are missing {} permissions.**".format(config.crossmark, perms), ephemeral=True)
+            return await ctx.respond(f"{config.crossmark} **You are missing {perms} permissions.**", ephemeral=True)
 
         if isinstance(err, commands.BotMissingPermissions):
             perms = "`" + '`, `'.join(err.missing_permissions) + "`"
-            return await ctx.respond("{} **I'm missing {} permissions**".format(config.crossmark, perms), ephemeral=True)
-
-        if isinstance(err, commands.MissingRequiredArgument):
-            return await ctx.respond("{} **`{}` is a required argument!**".format(config.crossmark, err.param.name), ephemeral=True)
+            return await ctx.respond(f"{config.crossmark} **I'm missing {perms} permissions**", ephemeral=True)
 
         if isinstance(err, commands.CommandOnCooldown):
-            return await ctx.respond(
-                "{} **This command is on cooldown for __{:.0f}__ more seconds.**".format(config.crossmark,
-                                                                                         err.retry_after), ephemeral=True)
+            return await ctx.respond(f"{config.crossmark} **This command is on cooldown for {round(err.retry_after)} more seconds.**", ephemeral=True)
 
         if isinstance(err, commands.MemberNotFound):
-            return await ctx.respond("{0} **Could not find user `{1}`**".format(config.confused, err.argument), ephemeral=True)
+            return await ctx.respond(f"{config.confused} **Could not find user `{err.argument}`", ephemeral=True)
 
         if isinstance(err, discord.NotFound):
             return await ctx.respond("I could not find the argument you have provided.", ephemeral=True)

--- a/cogs/events/errors.py
+++ b/cogs/events/errors.py
@@ -1,0 +1,41 @@
+import discord
+import config
+from discord.ext import commands
+
+
+# from cogs.admin import admin_only
+
+class error(commands.Cog, name="Error"):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_command_error(self, ctx, err):
+        if isinstance(err, commands.CommandNotFound):
+            return
+
+        if isinstance(err, commands.MissingPermissions):
+            perms = "`" + '`, `'.join(err.missing_permissions) + "`"
+            return await ctx.send("{} **You are missing {} permissions.**".format(config.crossmark, perms))
+
+        if isinstance(err, commands.BotMissingPermissions):
+            perms = "`" + '`, `'.join(err.missing_permissions) + "`"
+            return await ctx.send("{} **I'm missing {} permissions**".format(config.crossmark, perms))
+
+        if isinstance(err, commands.MissingRequiredArgument):
+            return await ctx.send("{} **`{}` is a required argument!**".format(config.crossmark, err.param.name))
+
+        if isinstance(err, commands.CommandOnCooldown):
+            return await ctx.send(
+                "{} **This command is on cooldown for __{:.0f}__ more seconds.**".format(config.crossmark,
+                                                                                         err.retry_after))
+
+        if isinstance(err, commands.MemberNotFound):
+            return await ctx.send("{0} **Could not find user `{1}`**".format(config.confused, err.argument))
+
+        if isinstance(err, discord.NotFound):
+            return await ctx.send("I could not find the argument you have provided.")
+
+
+def setup(bot):
+    bot.add_cog(error(bot))

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -13,7 +13,6 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Snuggle someone", options=[
         Option(str, name="users", description="Mention users to snuggle")
     ])
-    @Option(discord.Member, name="users", description="Wow")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def snuggle(self, ctx, *, members: str):
         """ Snuggle the specified people """

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -13,7 +13,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Snuggle someone")
     @option("members", str, description="Mention users to snuggle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def snuggle(self, ctx, members: str):
+    async def snuggle(self, ctx, members):
         """ Snuggle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "snuggled", 'snuggle', data.snuggle)
@@ -21,14 +21,14 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Hug someone")
     @option("members", str, description="Mention users to hug")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def hug(self, ctx, members: str):
+    async def hug(self, ctx, members):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "hugged", 'hug', data.hug, 'Hug')
 
     @slash_command(brief="Boop someone")
     @option("members", str, description="Mention users to boop")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def boop(self, ctx, members: str):
+    async def boop(self, ctx, members):
         """ Boop the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "booped", 'boop', data.boop)
@@ -36,7 +36,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Kiss someone")
     @option("members", str, description="Mention users to kiss")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def smooch(self, ctx, members: str):
+    async def smooch(self, ctx, members):
         """ Smooch the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "smooched", 'smooch', data.smooch)
@@ -44,7 +44,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Lick someone")
     @option("members", str, description="Mention users to lick")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def lick(self, ctx, members: str):
+    async def lick(self, ctx, members):
         """ Lick the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "licked", 'lick', data.lick)
@@ -52,7 +52,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Give someone bellyrubs")
     @option("members", str, description="Mention users to bellrub")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def bellyrub(self, ctx, members: str):
+    async def bellyrub(self, ctx, members):
         """ Give bellyrubs to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "bellyrubbed", 'rub the belly of', data.bellyrub, "Rub")
@@ -60,7 +60,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Nuzzle someone")
     @option("members", str, description="Mention users to nuzzle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def nuzzle(self, ctx, members: str):
+    async def nuzzle(self, ctx, members):
         """ Nuzzle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "nuzzled", 'nuzzles', data.nuzzle)
@@ -68,7 +68,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Cuddle someone")
     @option("members", str, description="Mention users to cuddle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def cuddle(self, ctx, members: str):
+    async def cuddle(self, ctx, members):
         """ Cuddle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "cuddled", 'cuddle', data.cuddle)
@@ -76,7 +76,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Feed someone")
     @option("members", str, description="Mention users to feed")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def feed(self, ctx, members: str):
+    async def feed(self, ctx, members):
         """ Feed the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "fed", 'feed', data.feed)
@@ -84,7 +84,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Glomp someone")
     @option("members", str, description="Mention users to glomp")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def glomp(self, ctx, members: str):
+    async def glomp(self, ctx, members):
         """ Glomp on the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "glomped", 'glomp', data.glomp)
@@ -92,7 +92,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Highfive someone")
     @option("members", str, description="Mention users to highfive")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def highfive(self, ctx, members: str):
+    async def highfive(self, ctx, members):
         """ Highfive the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "highfived", 'highfive', data.highfive)
@@ -100,7 +100,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Rawr")
     @option("members", str, description="Mention users to rawr at")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def rawr(self, ctx, members: str):
+    async def rawr(self, ctx, members):
         """ Rawr at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "rawred at", 'rawr at', data.rawr, "Rawr")
@@ -108,7 +108,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Howl to the moon, or someone")
     @option("members", str, description="Mention users to howl at")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def howl(self, ctx, members: str):
+    async def howl(self, ctx, members):
         """ Howl at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "howled at", 'howl at', data.awoo, "Howl")
@@ -116,7 +116,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Pat someone")
     @option("members", str, description="Mention users to pat")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def pat(self, ctx, members: str):
+    async def pat(self, ctx, members):
         """ Pat the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "pats", 'pat', data.pet, 'Pat')
@@ -124,7 +124,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Give a cookie to someone")
     @option("members", str, description="Mention users to give a cookie to")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def cookie(self, ctx, members: str):
+    async def cookie(self, ctx, members):
         """ Give cookies to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "gave a cookie to", 'give a cookie to', data.cookie, "Give a cookie")
@@ -132,7 +132,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Dance with someone")
     @option("members", str, description="Mention users to dance with", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def dance(self, ctx, members: str = None):
+    async def dance(self, ctx, members):
         """ Dance with someone """
         if not members:
             memberlist = None
@@ -143,7 +143,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Blush")
     @option("members", str, description="Mention users that made you blush", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def blush(self, ctx, members: str = None):
+    async def blush(self, ctx, members):
         """ Blush (optionally because of specified people) """
         if not members:
             memberlist = None
@@ -154,7 +154,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Be happy")
     @option("members", str, description="Mention users that made you happy", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def happy(self, ctx, members: str = None):
+    async def happy(self, ctx, members):
         """ Be happy (optionally because of specified people) """
         if not members:
             memberlist = None
@@ -165,8 +165,9 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Wag your tail ")
     @option("members", str, description="Mention users that made you wag", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def wag(self, ctx, members: str = None):
+    async def wag(self, ctx, members):
         """ Wag your tail (Optionally because of specified people) """
+        print(members)
         if not members:
             memberlist = None
         else:
@@ -200,10 +201,10 @@ class socials(commands.Cog, name="social"):
 
     @slash_command(brief="Give someone's avatar a rainbow overlay")
     @option("user", discord.Member, description="Select a user")
-    @option("border", bool, description="Make it a border?", required=False)
-    @option("server-avatar", bool, description="Use their server avatar?", required=False)
+    @option("border", bool, description="Make it a border?", required=False, default=False)
+    @option("server-avatar", bool, description="Use their server avatar?", required=False, default=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def gay(self, ctx, user: discord.Member = None, border: bool = False, server_avatar: bool = False):
+    async def gay(self, ctx, user, border, server_avatar):
         """ Gay overlay on avatar """
         link = ""
         if not user:

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -1,6 +1,6 @@
 import data
 from discord.ext import commands
-from discord import slash_command, Option
+from discord import slash_command, option, Option
 from utils import *
 import aiohttp
 
@@ -10,143 +10,127 @@ class socials(commands.Cog, name="social"):
         self.bot = bot
         self.help_icon = "♥️"
 
-    @slash_command(brief="Snuggle someone", options=[
-        Option(str, name="users", description="Mention users to snuggle")
-    ])
+    @slash_command(brief="Snuggle someone")
+    @option("members", str, description="Mention users to snuggle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def snuggle(self, ctx, *, members: str):
+    async def snuggle(self, ctx, members: str):
         """ Snuggle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "snuggled", 'snuggle', data.snuggle)
 
-    @slash_command(brief="Hug someone", options=[
-        Option(str, name="users", description="Mention users to hug ")
-    ])
+    @slash_command(brief="Hug someone")
+    @option("members", str, description="Mention users to hug")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def hug(self, ctx, *, members: str):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "hugged", 'hug', data.hug, 'Hug')
 
-    @slash_command(brief="Boop someone", options=[
-        Option(str, name="users", description="Mention users to boop")
-    ])
+    @slash_command(brief="Boop someone")
+    @option("members", str, description="Mention users to boop")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def boop(self, ctx, *, members: str):
         """ Boop the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "booped", 'boop', data.boop)
 
-    @slash_command(brief="Kiss someone", options=[
-        Option(str, name="users", description="Mention users to kiss")
-    ])
+    @slash_command(brief="Kiss someone")
+    @option("members", str, description="Mention users to kiss")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def smooch(self, ctx, *, members: str):
         """ Smooch the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "smooched", 'smooch', data.smooch)
 
-    @slash_command(brief="Lick someone", options=[
-        Option(str, name="users", description="Mention users to lick")
-    ])
+    @slash_command(brief="Lick someone")
+    @option("members", str, description="Mention users to lick")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def lick(self, ctx, *, members: str):
         """ Lick the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "licked", 'lick', data.lick)
 
-    @slash_command(brief="Give someone bellyrubs", options=[
-        Option(str, name="users", description="Mention users to bellyrub")
-    ])
+    @slash_command(brief="Give someone bellyrubs")
+    @option("members", str, description="Mention users to bellrub")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def bellyrub(self, ctx, *, members: str):
         """ Give bellyrubs to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "bellyrubbed", 'rub the belly of', data.bellyrub, "Rub")
 
-    @slash_command(brief="Nuzzle someone", options=[
-        Option(str, name="users", description="Mention users to nuzzle")
-    ])
+    @slash_command(brief="Nuzzle someone")
+    @option("members", str, description="Mention users to nuzzle")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def nuzzle(self, ctx, *, members: str):
         """ Nuzzle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "nuzzled", 'nuzzles', data.nuzzle)
 
-    @slash_command(brief="Cuddle someone", options=[
-        Option(str, name="users", description="Mention users to cuddle")
-    ])
+    @slash_command(brief="Cuddle someone")
+    @option("members", str, description="Mention users to cuddle")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def cuddle(self, ctx, *, members: str):
         """ Cuddle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "cuddled", 'cuddle', data.cuddle)
 
-    @slash_command(brief="Feed someone", options=[
-        Option(str, name="users", description="Mention users to feed")
-    ])
+    @slash_command(brief="Feed someone")
+    @option("members", str, description="Mention users to feed")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def feed(self, ctx, *, members: str):
         """ Feed the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "fed", 'feed', data.feed)
 
-    @slash_command(brief="Glomp someone", options=[
-        Option(str, name="users", description="Mention users to glomp")
-    ])
+    @slash_command(brief="Glomp someone")
+    @option("members", str, description="Mention users to glomp")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def glomp(self, ctx, *, members: str):
         """ Glomp on the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "glomped", 'glomp', data.glomp)
 
-    @slash_command(brief="Highfive someone", options=[
-        Option(str, name="users", description="Mention users to highfive")
-    ])
+    @slash_command(brief="Highfive someone")
+    @option("members", str, description="Mention users to highfive")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def highfive(self, ctx, *, members: str):
         """ Highfive the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "highfived", 'highfive', data.highfive)
 
-    @slash_command(brief="Rawr", options=[
-        Option(str, name="users", description="Mention users to rawr at")
-    ])
+    @slash_command(brief="Rawr")
+    @option("members", str, description="Mention users to rawr at")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def rawr(self, ctx, *, members: str):
         """ Rawr at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "rawred at", 'rawr at', data.rawr, "Rawr")
 
-    @slash_command(brief="Howl to the moon, or someone", options=[
-        Option(str, name="users", description="Mention users to howl at")
-    ])
+    @slash_command(brief="Howl to the moon, or someone")
+    @option("members", str, description="Mention users to howl at")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def awoo(self, ctx, *, members: str):
+    async def howl(self, ctx, *, members: str):
         """ Howl at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "howled at", 'howl at', data.awoo, "Howl")
 
-    @slash_command(brief="Pat someone", options=[
-        Option(str, name="users", description="Mention users to pat")
-    ])
+    @slash_command(brief="Pat someone")
+    @option("members", str, description="Mention users to pat")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def pat(self, ctx, *, members: str):
         """ Pat the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "pats", 'pat', data.pet, 'Pat')
 
-    @slash_command(brief="Give a cookie to someone", options=[
-        Option(str, name="users", description="Mention users to give a cookie to")
-    ])
+    @slash_command(brief="Give a cookie to someone")
+    @option("members", str, description="Mention users to give a cookie to")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def cookie(self, ctx, *, members: str):
         """ Give cookies to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "gave a cookie to", 'give a cookie to', data.cookie, "Give a cookie")
 
-    @slash_command(brief="Dance with someone", options=[
-        Option(str, name="users", description="Mention users to dance with", required=False)
-    ])
+    @slash_command(brief="Dance with someone")
+    @option("members", str, description="Mention users to dance with", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def dance(self, ctx, *, members: str = None):
         """ Dance with someone """
@@ -156,9 +140,8 @@ class socials(commands.Cog, name="social"):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "danced with", "dance with", data.dance, "Dance")
 
-    @slash_command(brief="Blush", options=[
-        Option(str, name="users", description="Mention users that made you blush", required=False)
-    ])
+    @slash_command(brief="Blush")
+    @option("members", str, description="Mention users that made you blush", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def blush(self, ctx, *, members: str = None):
         """ Blush (optionally because of specified people) """
@@ -168,9 +151,8 @@ class socials(commands.Cog, name="social"):
             memberlist = await mentionconverter(self, ctx, members)
         await feelings(ctx, memberlist, "blushes", data.blush)
 
-    @slash_command(brief="Be happy", options=[
-        Option(str, name="users", description="Mention users that made you happy", required=False)
-    ])
+    @slash_command(brief="Be happy")
+    @option("members", str, description="Mention users that made you happy", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def happy(self, ctx, *, members: str = None):
         """ Be happy (optionally because of specified people) """
@@ -180,9 +162,8 @@ class socials(commands.Cog, name="social"):
             memberlist = await mentionconverter(self, ctx, members)
         await feelings(ctx, memberlist, "smiles", data.happy)
 
-    @slash_command(brief="Wag your tail ", options=[
-        Option(str, name="users", description="Mention users that made you wag", required=False)
-    ])
+    @slash_command(brief="Wag your tail ")
+    @option("members", str, description="Mention users that made you wag", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def wag(self, ctx, *, members: str = None):
         """ Wag your tail (Optionally because of specified people) """
@@ -217,11 +198,10 @@ class socials(commands.Cog, name="social"):
                 e.set_image(url=js['image'])
                 await ctx.respond(embed=e)
 
-    @slash_command(options=[
-        discord.Option(discord.Member, name="user", description="Select a user"),
-        discord.Option(bool, name="border", description="Make it a border?", required=False),
-        discord.Option(bool, name="server-avatar", description="Use their server avatar?", required=False)
-    ])
+    @slash_command(brief="Give someone's avatar a rainbow overlay")
+    @option("user", discord.Member, description="Select a user")
+    @option("border", bool, description="Make it a border?", required=False)
+    @option("server-avatar", bool, description="Use their server avatar?", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def gay(self, ctx, user: discord.Member = None, border: bool = False, server_avatar: bool = False):
         """ Gay overlay on avatar """

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -200,11 +200,11 @@ class socials(commands.Cog, name="social"):
                 await ctx.respond(embed=e)
 
     @slash_command(brief="Give someone's avatar a rainbow overlay")
-    @option("user", discord.Member, description="Select a user")
+    @option("user", discord.Member, description="Select a user", required=False)
     @option("border", bool, description="Make it a border?", required=False, default=False)
     @option("server-avatar", bool, description="Use their server avatar?", required=False, default=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def gay(self, ctx, user, border, server_avatar):
+    async def gay(self, ctx, user, border=False, server_avatar=False):
         """ Gay overlay on avatar """
         link = ""
         if not user:

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -1,5 +1,6 @@
 import data
-from discord.ext import commands, bridge
+from discord.ext import commands
+from discord import slash_command, Option
 from utils import *
 import aiohttp
 
@@ -9,111 +10,144 @@ class socials(commands.Cog, name="social"):
         self.bot = bot
         self.help_icon = "♥️"
 
-    @bridge.bridge_command(brief="Snuggle someone")
+    @slash_command(brief="Snuggle someone", options=[
+        Option(str, name="users", description="Mention users to snuggle")
+    ])
+    @Option(discord.Member, name="users", description="Wow")
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def snuggle(self, ctx, *, members: str):
         """ Snuggle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "snuggled", 'snuggle', data.snuggle)
 
-    @bridge.bridge_command(brief="Hug someone")
+    @slash_command(brief="Hug someone", options=[
+        Option(str, name="users", description="Mention users to hug ")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def hug(self, ctx, *, members: str):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "hugged", 'hug', data.hug, 'Hug')
 
-    @bridge.bridge_command(brief="Boop someone")
+    @slash_command(brief="Boop someone", options=[
+        Option(str, name="users", description="Mention users to boop")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def boop(self, ctx, *, members: str):
         """ Boop the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "booped", 'boop', data.boop)
 
-    @bridge.bridge_command(brief="Smooch someone", aliases=["kiss"])
+    @slash_command(brief="Kiss someone", options=[
+        Option(str, name="users", description="Mention users to kiss")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def smooch(self, ctx, *, members: str):
         """ Smooch the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "smooched", 'smooch', data.smooch)
 
-    @bridge.bridge_command(brief="Lick someone")
+    @slash_command(brief="Lick someone", options=[
+        Option(str, name="users", description="Mention users to lick")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def lick(self, ctx, *, members: str):
         """ Lick the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "licked", 'lick', data.lick)
 
-    @bridge.bridge_command(brief="Give bellyrubs!")
+    @slash_command(brief="Give someone bellyrubs", options=[
+        Option(str, name="users", description="Mention users to bellyrub")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def bellyrub(self, ctx, *, members: str):
         """ Give bellyrubs to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "bellyrubbed", 'rub the belly of', data.bellyrub, "Rub")
 
-    @bridge.bridge_command(brief="Nuzzle someone")
+    @slash_command(brief="Nuzzle someone", options=[
+        Option(str, name="users", description="Mention users to nuzzle")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def nuzzle(self, ctx, *, members: str):
         """ Nuzzle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "nuzzled", 'nuzzles', data.nuzzle)
 
-    @bridge.bridge_command(brief="Cuddle someone")
+    @slash_command(brief="Cuddle someone", options=[
+        Option(str, name="users", description="Mention users to cuddle")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def cuddle(self, ctx, *, members: str):
         """ Cuddle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "cuddled", 'cuddle', data.cuddle)
 
-    @bridge.bridge_command(brief="Feed someone")
+    @slash_command(brief="Feed someone", options=[
+        Option(str, name="users", description="Mention users to feed")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def feed(self, ctx, *, members: str):
         """ Feed the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "fed", 'feed', data.feed)
 
-    @bridge.bridge_command(brief="Glomp someone")
+    @slash_command(brief="Glomp someone", options=[
+        Option(str, name="users", description="Mention users to glomp")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def glomp(self, ctx, *, members: str):
         """ Glomp on the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "glomped", 'glomp', data.glomp)
 
-    @bridge.bridge_command(brief="Highfive someone")
+    @slash_command(brief="Highfive someone", options=[
+        Option(str, name="users", description="Mention users to highfive")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def highfive(self, ctx, *, members: str):
         """ Highfive the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "highfived", 'highfive', data.highfive)
 
-    @bridge.bridge_command(brief="Rawrrrr")
+    @slash_command(brief="Rawr", options=[
+        Option(str, name="users", description="Mention users to rawr at")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def rawr(self, ctx, *, members: str):
         """ Rawr at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "rawred at", 'rawr at', data.rawr, "Rawr")
 
-    @bridge.bridge_command(brief="Howl to the moon, or someone", aliases=["howl"])
+    @slash_command(brief="Howl to the moon, or someone", options=[
+        Option(str, name="users", description="Mention users to howl at")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def awoo(self, ctx, *, members: str):
         """ Howl at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "howled at", 'howl at', data.awoo, "Howl")
 
-    @bridge.bridge_command(brief="pat someone!", aliases=["pet"])
+    @slash_command(brief="Pat someone", options=[
+        Option(str, name="users", description="Mention users to pat")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def pat(self, ctx, *, members: str):
         """ Pat the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "pats", 'pat', data.pet, 'Pat')
 
-    @bridge.bridge_command(brief="Gib cookie")
+    @slash_command(brief="Give a cookie to someone", options=[
+        Option(str, name="users", description="Mention users to give a cookie to")
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def cookie(self, ctx, *, members: str):
         """ Give cookies to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "gave a cookie to", 'give a cookie to', data.cookie, "Give a cookie")
 
-    @bridge.bridge_command(brief="Dance with someone")
+    @slash_command(brief="Dance with someone", options=[
+        Option(str, name="users", description="Mention users to dance with", required=False)
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def dance(self, ctx, *, members: str = None):
         """ Dance with someone """
@@ -123,37 +157,43 @@ class socials(commands.Cog, name="social"):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "danced with", "dance with", data.dance, "Dance")
 
-    @bridge.bridge_command(brief="Blushies!")
+    @slash_command(brief="Blush", options=[
+        Option(str, name="users", description="Mention users that made you blush", required=False)
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def blush(self, ctx, *, members: str = "None"):
+    async def blush(self, ctx, *, members: str = None):
         """ Blush (optionally because of specified people) """
-        if members == "None":
+        if not members:
             memberlist = None
         else:
             memberlist = await mentionconverter(self, ctx, members)
         await feelings(ctx, memberlist, "blushes", data.blush)
 
-    @bridge.bridge_command(brief="Be happy")
+    @slash_command(brief="Be happy", options=[
+        Option(str, name="users", description="Mention users that made you happy", required=False)
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def happy(self, ctx, *, members: str = "None"):
+    async def happy(self, ctx, *, members: str = None):
         """ Be happy (optionally because of specified people) """
-        if members == "None":
+        if not members:
             memberlist = None
         else:
             memberlist = await mentionconverter(self, ctx, members)
         await feelings(ctx, memberlist, "smiles", data.happy)
 
-    @bridge.bridge_command(brief="wag yer tail")
+    @slash_command(brief="Wag your tail ", options=[
+        Option(str, name="users", description="Mention users that made you wag", required=False)
+    ])
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def wag(self, ctx, *, members: str = "None"):
+    async def wag(self, ctx, *, members: str = None):
         """ Wag your tail (Optionally because of specified people) """
-        if members == "None":
+        if not members:
             memberlist = None
         else:
             memberlist = await mentionconverter(self, ctx, members)
         await feelings(ctx, memberlist, "wags their tail", data.wag)
 
-    @bridge.bridge_command()
+    @slash_command()
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def fact(self, ctx):
         """ Get a random animal fact """
@@ -166,7 +206,7 @@ class socials(commands.Cog, name="social"):
 
                 await ctx.respond(js['fact'])
 
-    @bridge.bridge_command()
+    @slash_command()
     @commands.cooldown(1, 5, commands.BucketType.user)
     async def fox(self, ctx):
         """ Get a random fox """
@@ -178,7 +218,7 @@ class socials(commands.Cog, name="social"):
                 e.set_image(url=js['image'])
                 await ctx.respond(embed=e)
 
-    @bridge.bridge_command(options=[
+    @slash_command(options=[
         discord.Option(discord.Member, name="user", description="Select a user"),
         discord.Option(bool, name="border", description="Make it a border?", required=False),
         discord.Option(bool, name="server-avatar", description="Use their server avatar?", required=False)

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -1,6 +1,6 @@
 import data
 from discord.ext import commands
-from discord import slash_command, option, Option
+from discord import slash_command, option
 from utils import *
 import aiohttp
 
@@ -21,14 +21,14 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Hug someone")
     @option("members", str, description="Mention users to hug")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def hug(self, ctx, *, members: str):
+    async def hug(self, ctx, members: str):
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "hugged", 'hug', data.hug, 'Hug')
 
     @slash_command(brief="Boop someone")
     @option("members", str, description="Mention users to boop")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def boop(self, ctx, *, members: str):
+    async def boop(self, ctx, members: str):
         """ Boop the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "booped", 'boop', data.boop)
@@ -36,7 +36,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Kiss someone")
     @option("members", str, description="Mention users to kiss")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def smooch(self, ctx, *, members: str):
+    async def smooch(self, ctx, members: str):
         """ Smooch the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "smooched", 'smooch', data.smooch)
@@ -44,7 +44,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Lick someone")
     @option("members", str, description="Mention users to lick")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def lick(self, ctx, *, members: str):
+    async def lick(self, ctx, members: str):
         """ Lick the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "licked", 'lick', data.lick)
@@ -52,7 +52,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Give someone bellyrubs")
     @option("members", str, description="Mention users to bellrub")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def bellyrub(self, ctx, *, members: str):
+    async def bellyrub(self, ctx, members: str):
         """ Give bellyrubs to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "bellyrubbed", 'rub the belly of', data.bellyrub, "Rub")
@@ -60,7 +60,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Nuzzle someone")
     @option("members", str, description="Mention users to nuzzle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def nuzzle(self, ctx, *, members: str):
+    async def nuzzle(self, ctx, members: str):
         """ Nuzzle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "nuzzled", 'nuzzles', data.nuzzle)
@@ -68,7 +68,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Cuddle someone")
     @option("members", str, description="Mention users to cuddle")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def cuddle(self, ctx, *, members: str):
+    async def cuddle(self, ctx, members: str):
         """ Cuddle the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "cuddled", 'cuddle', data.cuddle)
@@ -76,7 +76,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Feed someone")
     @option("members", str, description="Mention users to feed")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def feed(self, ctx, *, members: str):
+    async def feed(self, ctx, members: str):
         """ Feed the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "fed", 'feed', data.feed)
@@ -84,7 +84,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Glomp someone")
     @option("members", str, description="Mention users to glomp")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def glomp(self, ctx, *, members: str):
+    async def glomp(self, ctx, members: str):
         """ Glomp on the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "glomped", 'glomp', data.glomp)
@@ -92,7 +92,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Highfive someone")
     @option("members", str, description="Mention users to highfive")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def highfive(self, ctx, *, members: str):
+    async def highfive(self, ctx, members: str):
         """ Highfive the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "highfived", 'highfive', data.highfive)
@@ -100,7 +100,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Rawr")
     @option("members", str, description="Mention users to rawr at")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def rawr(self, ctx, *, members: str):
+    async def rawr(self, ctx, members: str):
         """ Rawr at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "rawred at", 'rawr at', data.rawr, "Rawr")
@@ -108,7 +108,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Howl to the moon, or someone")
     @option("members", str, description="Mention users to howl at")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def howl(self, ctx, *, members: str):
+    async def howl(self, ctx, members: str):
         """ Howl at the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "howled at", 'howl at', data.awoo, "Howl")
@@ -116,7 +116,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Pat someone")
     @option("members", str, description="Mention users to pat")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def pat(self, ctx, *, members: str):
+    async def pat(self, ctx, members: str):
         """ Pat the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "pats", 'pat', data.pet, 'Pat')
@@ -124,7 +124,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Give a cookie to someone")
     @option("members", str, description="Mention users to give a cookie to")
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def cookie(self, ctx, *, members: str):
+    async def cookie(self, ctx, members: str):
         """ Give cookies to the specified people """
         memberlist = await mentionconverter(self, ctx, members)
         await interactions(ctx, memberlist, "gave a cookie to", 'give a cookie to', data.cookie, "Give a cookie")
@@ -132,7 +132,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Dance with someone")
     @option("members", str, description="Mention users to dance with", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def dance(self, ctx, *, members: str = None):
+    async def dance(self, ctx, members: str = None):
         """ Dance with someone """
         if not members:
             memberlist = None
@@ -143,7 +143,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Blush")
     @option("members", str, description="Mention users that made you blush", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def blush(self, ctx, *, members: str = None):
+    async def blush(self, ctx, members: str = None):
         """ Blush (optionally because of specified people) """
         if not members:
             memberlist = None
@@ -154,7 +154,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Be happy")
     @option("members", str, description="Mention users that made you happy", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def happy(self, ctx, *, members: str = None):
+    async def happy(self, ctx, members: str = None):
         """ Be happy (optionally because of specified people) """
         if not members:
             memberlist = None
@@ -165,7 +165,7 @@ class socials(commands.Cog, name="social"):
     @slash_command(brief="Wag your tail ")
     @option("members", str, description="Mention users that made you wag", required=False)
     @commands.cooldown(1, 5, commands.BucketType.user)
-    async def wag(self, ctx, *, members: str = None):
+    async def wag(self, ctx, members: str = None):
         """ Wag your tail (Optionally because of specified people) """
         if not members:
             memberlist = None

--- a/utils.py
+++ b/utils.py
@@ -11,8 +11,6 @@ class Colors:
 
 async def interactions(ctx, members, name, error_name, giflist, altname=None):
     image = random.choice(giflist)
-    if len(set(members)) == 0:
-        return await ctx.respond(f'You must specify at least one user to {error_name}!', ephemeral=True)
     display_giflist = []
     for x in members:
         display_giflist.append(x.display_name)


### PR DESCRIPTION
Initial conversion of every command to slash commands, using the discord.slash_command and discord.option decorators
Also removing a few unnecessary typehints and * arguments
