### PR TITLE
Remove obsolete attributes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,7 +6,7 @@ from config import token
 intents = Intents(guilds=True, guild_messages=True)
 # intents.message_content = True #Uncomment this if you use prefixed command that are not mentions
 bot = bridge.Bot(intents=intents, command_prefix=">>", status=Status.dnd,
-                 activity=Activity(type=ActivityType.watching, name="you (prefix: >>)"))
+                 activity=Activity(type=ActivityType.watching, name="you"))
 
 
 class MyNewHelp(commands.MinimalHelpCommand):

--- a/cogs/socials.py
+++ b/cogs/socials.py
@@ -8,7 +8,6 @@ import aiohttp
 class socials(commands.Cog, name="social"):
     def __init__(self, bot):
         self.bot = bot
-        self.help_icon = "♥️"
 
     @slash_command(brief="Snuggle someone")
     @option("members", str, description="Mention users to snuggle")


### PR DESCRIPTION
This PR removes the prefix part of the status, as to not mislead people into thinking that we still support messsage commands.
Additionally, i removed the `self.help_icon` attribute from the class as this was an old thing from exorium's paginated help menu.