### PR TITLE
Fix disabled commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -53,7 +53,6 @@ async def block_disabled_commands(ctx):
     elif cog.lower() in result and result[cog.lower()]:
         return True
     else:
-        await ctx.respond(f'{cog} is disabled here.', ephemeral=True)
         return False
 
 bot.run(token)

--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,6 @@
 import discord
 import json
 from discord import Intents, Status, Activity, ActivityType
-from discord.ext import commands
 
 from config import token
 from utilities.database import mysql_login, selector
@@ -9,17 +8,6 @@ from utilities.database import mysql_login, selector
 intents = Intents(guilds=True)
 bot = discord.Bot(intents=intents, status=Status.dnd,
                   activity=Activity(type=ActivityType.watching, name="you"))
-
-
-class MyNewHelp(commands.MinimalHelpCommand):
-    async def send_pages(self):
-        destination = self.get_destination()
-        for page in self.paginator.pages:
-            emby = discord.Embed(description=page)
-            await destination.send(embed=emby)
-
-
-bot.help_command = MyNewHelp()
 
 bot.load_extensions("cogs")  # Loads all cogs in the cogs folder
 bot.load_extensions("cogs.events")

--- a/bot.py
+++ b/bot.py
@@ -43,7 +43,7 @@ async def on_ready():
 
 @bot.check
 async def block_disabled_commands(ctx):
-    result = (await selector("SELECT config FROM settings WHERE GUILD = %s", [ctx.guild.id]))
+    result = (await selector("SELECT config FROM settings WHERE GUILD = %s", [ctx.guild.id]))[0]
     result = json.loads(result)
 
     cog = ctx.cog.__class__.__name__

--- a/cogs/events/errors.py
+++ b/cogs/events/errors.py
@@ -29,6 +29,9 @@ class Error(commands.Cog, name="Error"):
         if isinstance(err, discord.NotFound):
             return await ctx.respond(f"{Emotes.confused} I could not find the argument you have provided.", ephemeral=True)
 
+        if isinstance(err, discord.errors.CheckFailure):
+            return await ctx.respond(f"{Emotes.crossmark} **{ctx.cog.__class__.__name__}** is disabled here.", ephemeral=True)
+
         else:
             embed = discord.Embed(colour=Colors.red)
             embed.description = f"You can join our support discord [here]({Links.discord})"


### PR DESCRIPTION
This fixes a critical issue where commands in a disabled cog would say it's disabled, but proceed to show an error prompt. It also reverts #30, as somehow that PR broke the bot as well, which now runs fine with the PR reverted.

## I realize using a generic CheckFailure error catcher is shady, but as long as we have no other checks - i see no problem in using it.