### PR TITLE
Fix guild not in settings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -3,8 +3,8 @@ import json
 from discord import Intents, Status, Activity, ActivityType
 
 from config import token
-from utilities.database import mysql_login, selector
-
+from utilities.database import mysql_login, selector, modifyData
+from datetime import datetime
 intents = Intents(guilds=True)
 bot = discord.Bot(intents=intents, status=Status.dnd,
                   activity=Activity(type=ActivityType.watching, name="you"))
@@ -43,6 +43,12 @@ async def on_ready():
 
 @bot.check
 async def block_disabled_commands(ctx):
+    result = (await selector("SELECT config FROM settings WHERE GUILD = %s", [ctx.guild.id]))
+    if result == ():
+        configuration = {'currency': True, 'socials': True}
+        configuration = json.dumps(configuration)
+        await modifyData("INSERT INTO settings (GUILD, config) VALUES (%s, %s)", [ctx.guild.id, configuration])
+        print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Corrected guild absence in settings upon command execution.")
     result = (await selector("SELECT config FROM settings WHERE GUILD = %s", [ctx.guild.id]))[0]
     result = json.loads(result)
 

--- a/cogs/events/errors.py
+++ b/cogs/events/errors.py
@@ -35,7 +35,7 @@ class Error(commands.Cog, name="Error"):
         else:
             embed = discord.Embed(colour=Colors.red)
             embed.description = f"You can join our support discord [here]({Links.discord})"
-            await ctx.respond(f"{Emotes.confused} An error has occurred. Please report this.", embed=embed)
+            await ctx.respond(f"{Emotes.confused} An error has occurred. Please report this.", embed=embed, ephemeral=True)
             raise Exception(''.join(traceback.format_exception(type(err), err, err.__traceback__)))
 
 

--- a/cogs/events/logs.py
+++ b/cogs/events/logs.py
@@ -14,10 +14,6 @@ class Logs(commands.Cog, name="Logs"):
     @commands.Cog.listener()
     async def on_application_command(self, ctx):
         if ctx.guild:
-            if (await selector("SELECT * FROM settings WHERE GUILD = %s", [ctx.guild.id])) == ():
-                configuration = {'currency': True, 'socials': True}
-                configuration = json.dumps(configuration)
-                await modifyData("INSERT INTO settings (GUILD, config) VALUES (%s, %s)", [ctx.guild.id, configuration])
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - {ctx.guild.name} | {ctx.author} > {ctx.command}")
         else:
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Direct Messages | {ctx.author} > {ctx.command}")

--- a/cogs/events/logs.py
+++ b/cogs/events/logs.py
@@ -2,7 +2,7 @@ import json
 import traceback
 from datetime import datetime
 from discord.ext import commands
-from utilities.database import mysql_login
+from utilities.database import mysql_login, selector, modifyData
 
 
 # from cogs.admin import admin_only

--- a/cogs/events/logs.py
+++ b/cogs/events/logs.py
@@ -14,6 +14,10 @@ class Logs(commands.Cog, name="Logs"):
     @commands.Cog.listener()
     async def on_application_command(self, ctx):
         if ctx.guild:
+            if (await selector("SELECT * FROM settings WHERE GUILD = %s", [ctx.guild.id])) == ():
+                configuration = {'currency': True, 'socials': True}
+                configuration = json.dumps(configuration)
+                await modifyData("INSERT INTO settings (GUILD, config) VALUES (%s, %s)", [ctx.guild.id, configuration])
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - {ctx.guild.name} | {ctx.author} > {ctx.command}")
         else:
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Direct Messages | {ctx.author} > {ctx.command}")

--- a/cogs/events/logs.py
+++ b/cogs/events/logs.py
@@ -2,7 +2,7 @@ import json
 import traceback
 from datetime import datetime
 from discord.ext import commands
-from utilities.database import mysql_login, selector, modifyData
+from utilities.database import selector, modifyData
 
 
 # from cogs.admin import admin_only
@@ -31,12 +31,8 @@ class Logs(commands.Cog, name="Logs"):
         configuration = json.dumps(configuration)
 
         try:
-            cursor = await mysql_login()
-            database = cursor.cursor()
-            database.execute("INSERT INTO settings (GUILD, config) VALUES (%s, %s)", [guild.id, configuration])
-            cursor.commit()
-            database.close()
-            cursor.close()
+            await modifyData("INSERT INTO settings (GUILD, config) VALUES (%s, %s)", [guild.id, configuration])
+
         except Exception as error:
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Received fatal connection | Could not complete operation")
             traceback.print_tb(error.__traceback__)
@@ -50,12 +46,7 @@ class Logs(commands.Cog, name="Logs"):
         print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Deleting configuration settings from database...")
 
         try:
-            cursor = await mysql_login()
-            database = cursor.cursor()
-            database.execute("DELETE FROM settings WHERE GUILD = %s", [guild.id])
-            cursor.commit()
-            database.close()
-            cursor.close()
+            await modifyData("DELETE FROM settings WHERE GUILD = %s", [guild.id])
         except Exception as error:
             print(f"{datetime.now().__format__('%a %d %b %y, %H:%M:%S')} - Received fatal connection | Could not complete operation")
             traceback.print_tb(error.__traceback__)


### PR DESCRIPTION
This PR ensures that when a server is not present in the settings database, it'll be added and the command will be ran successfully. These types of scenarios tend to happen when the on_guild_join event cannot fire as a result of the bot being offline, or non-responsive.

Additionally requesting @Soapy7261's review on this as well.